### PR TITLE
[WIP]購入確認ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 @import "modules/logout";
 @import "modules/credit_card";
 @import "modules/items_show";
+@import "modules/confirm";

--- a/app/assets/stylesheets/modules/_confirm.scss
+++ b/app/assets/stylesheets/modules/_confirm.scss
@@ -120,23 +120,11 @@
       &__head{
         display: flex;
         justify-content: space-between;
-        &--left{
-        }
-        &--right{
-        }
       }
       &--card_info{
         padding-top: 30px;
         p{
           padding: 5px 0 ;
-        }
-        &__type{
-
-        }
-        &__num{
-
-        }
-        &__date{
         }
       }
     }
@@ -151,10 +139,6 @@
       &__hedder{
         display: flex;
         justify-content: space-between;
-        &__left{
-        }
-        &__right{
-        }
       }
       ul{
         padding-top: 30px;

--- a/app/assets/stylesheets/modules/_confirm.scss
+++ b/app/assets/stylesheets/modules/_confirm.scss
@@ -1,0 +1,191 @@
+* {
+  box-sizing: border-box;
+  font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
+}
+
+@mixin back_color_gry{
+  background-color: #f8f8f8;
+}
+@mixin main_width{
+  margin: 0 auto;
+  width: 700px;
+  background-color: white;
+}
+
+@mixin border{
+  content: '';
+  position: absolute;
+  left: 50%;
+  display: inline-block;
+  width: 80%;
+  height: 2px;
+  bottom: 0px;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+  @include back_color_gry;
+  border-radius: 2px;
+}
+@mixin btn{
+  height: 40px;
+  line-height: 40px;
+  width: 200px;
+  color: white;
+  border-radius: 100px;
+  text-align: center;
+}
+.comfirm_wrapper{
+  img{
+    object-fit: cover;
+  }
+  a{
+    text-decoration: none;
+    color:#3CCACE;
+  }
+  h3{
+    font-weight: bold;
+    font-size: 18px;
+  }
+  padding:100px 0;
+  width: 100vw;
+  height: 100%;
+  @include back_color_gry;
+  .comfirm_main {
+    @include main_width;
+    &--head{
+      height: 100px;
+      line-height: 100px;
+      text-align: center;
+      font-size: 24px;
+      font-weight: bold;;
+      position: relative;
+    }
+    &--head::after{
+      @include border;
+    }
+    &__item{
+      height: 160px;
+      padding: 30px 120px;
+      display: flex;
+      position: relative;
+      &__left{
+        height: 100px;
+        width: 100px;
+      }
+      &__right{
+          padding-left: 30px;
+        &__title{
+          font-size: 16px;
+          height: 80px;
+        }
+        &__lower{
+          display: flex;
+          &--detail{
+            font-size: 14px;
+          }
+          &--price{
+            margin-left: 10px;
+            font-size: 18px;
+            font-weight: bold;
+          }
+        }
+      }
+    }
+    &__item::after{
+      @include border;
+      bottom: 0px
+    }
+    &__price{
+      height: 160px;
+      padding: 30px 120px;
+      display: flex;
+      line-height: 100px;
+      font-weight: bold;
+      font-size: 20px;
+      position: relative;
+      &__left{
+      }
+      &__right{
+        padding-left: 100px;
+        font-size: 22px;
+      }
+    }
+    &__price::after{
+      @include border;
+      bottom: 0px;
+    }
+    &__payment{
+      height: 220px;
+      padding: 30px 120px;
+      position: relative;
+      &__head{
+        display: flex;
+        justify-content: space-between;
+        &--left{
+        }
+        &--right{
+        }
+      }
+      &--card_info{
+        padding-top: 30px;
+        p{
+          padding: 5px 0 ;
+        }
+        &__type{
+
+        }
+        &__num{
+
+        }
+        &__date{
+        }
+      }
+    }
+    &__payment::after{
+      @include border;
+      bottom: 0px;
+    }
+    &__address{
+      height: 200px;
+      padding: 30px 120px;
+      position: relative;
+      &__hedder{
+        display: flex;
+        justify-content: space-between;
+        &__left{
+        }
+        &__right{
+        }
+      }
+      ul{
+        padding-top: 30px;
+        li{
+          padding: 2px 0 ;
+        }
+      }
+    }
+    &__address::after{
+      @include border;
+      bottom: 0px;
+    }
+    &__buy{
+      display: flex;
+      height: 120px;
+      padding: 30px 120px;
+      a{
+        color: white;
+      }
+      &--btn{
+        @include btn;
+        margin-left: 10px;
+        background:  red;
+        letter-spacing: 5px; 
+      }
+      &--back_btn{
+        @include btn;
+        margin-left: 50px;
+        background-color:  #3CCACE;
+        letter-spacing: 10px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_footer.scss
+++ b/app/assets/stylesheets/modules/_footer.scss
@@ -34,3 +34,45 @@
     height: 46px;
   }
 }
+
+// マークオンリー用
+footer {
+  position: relative;
+  right: 0;
+  left: 0;
+
+  width: 456px;
+  height: 220px;
+ 
+  text-align: center;
+  margin: 0 auto;
+  padding: 40px 0;
+
+  ul {
+    display: flex;
+    font-size: 14px;
+    display: flex;
+    justify-content: space-between;
+    a {
+        text-decoration: none;
+        color:grey;
+    }
+  }
+
+  a {
+    
+    .footer-logo {
+      margin:40px 0;
+      img {
+        width: 185px;
+        height:49px;
+      }
+    }
+  }
+  p {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    left: 0;
+  }
+}

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -105,3 +105,21 @@
     }
   }
 }
+
+// マークオンリー用
+header {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height:128px;
+
+  a{
+    margin: 40px 0 40px;
+    .header-logo {
+      img {
+        width: 185px;
+        height:49px;
+      }
+    }
+  }
+}

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -1,0 +1,64 @@
+%header.login-page-header
+  =link_to root_path do
+    .header-logo
+      = image_tag 'logo.png'
+.comfirm_wrapper
+  .comfirm_main 
+    %h2.comfirm_main--head
+      購入内容の確認
+    .comfirm_main__item
+      .comfirm_main__item__left
+        = image_tag src="IMG_main.jpeg", alt: 'img画像',  height: '100px', width: '100px', class: 'comfirm_main__item__left--img'
+      .comfirm_main__item__right
+        %h6.comfirm_main__item__right__title
+          今日の晩ご飯
+        .comfirm_main__item__right__lower
+          %p.comfirm_main__item__right__lower--detail
+            送料込み
+          %p.comfirm_main__item__right__lower--price
+            ¥1000
+    .comfirm_main__price
+      %h3.comfirm_main__price__left
+        支払い金額
+      %p.comfirm_main__price__right
+        ¥1000
+    .comfirm_main__payment
+      .comfirm_main__payment__head
+        %h3.comfirm_main__payment__head--left
+          支払い方法
+        =link_to "変更する >", "#", class:"comfirm_main__payment__head--right"
+      .comfirm_main__payment--card_info
+        %p.comfirm_main__payment--card_info__type
+          クレジットカード
+        %p.comfirm_main__payment--card_info__num
+          ***********1234
+        %p.comfirm_main__payment--card_info__date
+          有効期限 02 / 23
+    .comfirm_main__address
+      .comfirm_main__address__hedder
+        %h3.comfirm_main__address__hedder__left
+          配送先
+        = link_to "変更する >" ,"#", class:"comfirm_main__address__hedder__right"
+      %ul.comfirm_main__address__area
+        %li.comfirm_main__address__area--number
+          〒120-0006
+        %li.comfirm_main__address__area--main
+          東京都港区その辺にあるにコンビニの横
+        %li.comfirm_main__address__area--name
+          山田ゴンザレス
+    .comfirm_main__buy
+      = link_to "購入する" ,"#", class:"comfirm_main__buy--btn"
+      = link_to "戻る" , "#", class:"comfirm_main__buy--back_btn"
+%footer.login-page-footer
+  %ul.footer-links
+    %li
+      =link_to "プライバシーポリシー", root_path
+    %li
+      =link_to "利用契約", root_path
+    %li
+      =link_to "特定取引に関する表記"
+  =link_to root_path do
+    .footer-logo
+      =image_tag 'logo-white.png'
+  %p
+    ©a班 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
-  resources :items
+  resources :items do
+    member do
+      get 'confirm'
+    end
+  end
   resources :user, only: [:show] do
     collection do
       get 'logout', to: 'user#logout'


### PR DESCRIPTION
##What
商品購入確認ページの実装

##Why
購入する商品の詳細画面からボタンを押下することで、購入する画面へ遷移。
そのまま購入することはなく一度確認ページを挟むことで、ユーザーのボタンの押し間違いなどによるミスを少なくすることができる。

<該当画面のキャプチャ>
https://gyazo.com/83f3cf2d70c424c2811ee4918d112428
