### PR TITLE
マイページのメニューで選べる機能の更新

### DIFF
--- a/app/assets/javascripts/amount_calculation.js
+++ b/app/assets/javascripts/amount_calculation.js
@@ -4,9 +4,9 @@ $(function(){
     // 販売価格の入力欄の右のボタンを動かしたり、直接キー入力すると動きます
     let amount = $( this ).val();
     // 販売価格の入力欄に入力された値を変数「amount」に代入
-    let fee = Math.ceil(amount * 0.1);
+    let fee = "¥" + Math.ceil(amount * 0.1);
     // 販売手数料は10%としています。またMath.ceilメソッドで1円単位に切り上げています。
-    let gain = Math.floor(amount * 0.9);
+    let gain = "¥" + Math.floor(amount * 0.9);
     // 利益は残りの金額。Math.floorメソッドで、1円単位で切り捨てておけば「販売価格 = 販売手数料 + 販売利益」が成り立ちます。
     $('.price__sales_commission--fees_mark').html(fee);
     // htmlメソッドを使って販売手数料の欄を丸ごと書き換えます。

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,4 @@
 @import "categories/parent";
 @import "modules/mypage_purchase";
 @import "modules/soldout";
+@import "modules/edit-user-mail";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,3 +27,4 @@
 @import "modules/mypage_purchase";
 @import "modules/soldout";
 @import "modules/edit-user-mail";
+@import "modules/personal-infomation";

--- a/app/assets/stylesheets/config/colors.scss
+++ b/app/assets/stylesheets/config/colors.scss
@@ -6,3 +6,6 @@ $main_color: #3CCACE;
 $background: #f8f8f8;
 // エラー文などのアラートを出すときの背景色、濃いオレンジ色
 $alert: #ff5100;
+// サブの青い色
+$sub_blue: #0099e8;
+

--- a/app/assets/stylesheets/modules/_edit-user-mail.scss
+++ b/app/assets/stylesheets/modules/_edit-user-mail.scss
@@ -1,0 +1,72 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
+}
+
+.edit-user {
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  margin-bottom: 50px;
+
+
+  h2 {
+    height: 60px;
+    padding-top: 20px;
+    color: $main_color;
+    font-size: 28px;
+    font-weight: bold;
+    text-align: center;
+  }
+
+  form {
+  
+    .field {
+
+      margin: 20px 0;
+      label {
+        color: $sub_blue;
+        font-weight: bold;
+        font-size: 20px;
+      }
+      
+      input {
+        width: 330px;
+        height: 48px;
+        padding : 10px 16px 8px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        margin: 8px;
+      }
+      span {
+        color: $alert;
+      }
+    }
+
+    .change-btn {
+      width: 328px;
+      height: 50px;
+      background-color: $main_color;
+      border: 1px solid $main_color;
+      border-radius: 4px;
+      color: $white;
+      cursor: pointer;
+    }
+
+  }
+
+  .back-to-user-mypage {
+    margin: auto;
+    padding-top: 12px;
+    width: 328px;
+    height: 50px;
+    background-color: $sub_blue;
+    border: 1px solid $sub_blue;
+    border-radius: 4px;
+    color: $white;
+    cursor: pointer;
+  }
+
+}

--- a/app/assets/stylesheets/modules/_mypage_top.scss
+++ b/app/assets/stylesheets/modules/_mypage_top.scss
@@ -67,6 +67,7 @@
 }
 
 .main-information {
+  padding-bottom: 50px;
 // プロフィール画像・ニックネーム・評価・出品数
   &__showMypage-contents1 {
     display: flex;
@@ -114,4 +115,18 @@
       }
     }
   }
+}
+
+.nickname_change {
+  margin: auto;
+  align-items: center;
+  text-align: center;
+  padding-top: 12px;
+  width: 328px;
+  height: 50px;
+  background-color: $main_color;
+  border: 1px solid $main_color;
+  border-radius: 4px;
+  color: $white;
+  cursor: pointer;
 }

--- a/app/assets/stylesheets/modules/_personal-infomation.scss
+++ b/app/assets/stylesheets/modules/_personal-infomation.scss
@@ -27,20 +27,23 @@
     margin: 10px 0;
   }
 
-  div {
+  .content {
     margin: 15px 0;
   }
 
-  .name__ja {
+  .destination {
+    margin-top: 25px;
+    font-weight: bold;
+    color: $main_color;
+  }
+
+  .name {
     display: flex;
     
-    .last_name {
+    &__last {
       margin-right: 10px;
     }
-    .last_name__kana {
-      margin-right: 10px;
-    }
-    
+
   }
 
   .link-btn {

--- a/app/assets/stylesheets/modules/_personal-infomation.scss
+++ b/app/assets/stylesheets/modules/_personal-infomation.scss
@@ -1,0 +1,45 @@
+.mypage__personal_infomation {
+  background-color: $background;
+  padding: 50px 120px;
+  display: flex;
+}
+
+.personal_infomation {
+  width: 100%;
+  margin-left: 50px;
+  padding: 50px;
+  background-color: $white;
+
+  .suggestion {
+    text-align: center;
+    margin: 50px;
+  }
+
+  h1 {
+    color: $main_color;
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+  }
+
+  span {
+    color: $sub_blue;
+    margin: 10px 0;
+  }
+
+  div {
+    margin: 15px 0;
+  }
+
+  .link-btn {
+    margin: auto;
+    height: 50px;
+    width: 320px;
+    padding-top: 12px;
+    text-align: center;
+    background-color: $main_color;
+    color: $white;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+}

--- a/app/assets/stylesheets/modules/_personal-infomation.scss
+++ b/app/assets/stylesheets/modules/_personal-infomation.scss
@@ -31,6 +31,18 @@
     margin: 15px 0;
   }
 
+  .name__ja {
+    display: flex;
+    
+    .last_name {
+      margin-right: 10px;
+    }
+    .last_name__kana {
+      margin-right: 10px;
+    }
+    
+  }
+
   .link-btn {
     margin: auto;
     height: 50px;

--- a/app/assets/stylesheets/modules/_register-address.scss
+++ b/app/assets/stylesheets/modules/_register-address.scss
@@ -14,6 +14,7 @@ a:hover {
   align-items: center;
   flex-direction: column;
   text-align: center;
+  margin-bottom: 50px;
 
   &__header {
     display: flex;
@@ -87,4 +88,15 @@ a:hover {
     color: $white;
     cursor: pointer;
   }
+}
+.back-to-user-mypage {
+  margin: auto;
+  padding-top: 12px;
+  width: 328px;
+  height: 50px;
+  background-color: $sub_blue;
+  border: 1px solid $sub_blue;
+  border-radius: 4px;
+  color: $white;
+  cursor: pointer;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -43,6 +43,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     super
   end
 
+
   def destroy
     super
   end
@@ -61,6 +62,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def set_categorys
     @categories = Category.all  
   end
+
+  # def user_params
+  #   params.require(:user).permit(:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday)
+  # end
 
   protected
   

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  before_action :set_categorys
+
   def new
     @user = User.new
   end
@@ -53,6 +55,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def cancel
   #   super
   # end
+
+  private
+  
+  def set_categorys
+    @categories = Category.all  
+  end
 
   protected
   

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -33,20 +33,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
     sign_in(:user, @user)
   end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
+  def edit
+    super
+  end
 
-  # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    super
+  end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,6 +60,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     params.require(:address).permit(:destination_first_name, :destination_last_name, :destination_first_name_kana, :destination_last_name_kana, :postal_code, :prefecture_id, :city, :block, :building, :phone_numeber)
   end
 
+  def after_update_path_for(resource)
+    user_path(resource)
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :set_categorys
 
   def show
-    @nickname = User.find(params[:id]).nickname
+    @nickname = current_user.nickname
   end
 
   def personal_infomation

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,12 @@ class UsersController < ApplicationController
   def show
     @nickname = current_user.nickname 
   end
+
+  def personal_infomation
+    @user = User.find(params[:id])
+    @address = Address.find(params[:id])
+  end
+  
   def purchase_item
     @items = Item.where(buyer_id: current_user.id).page(params[:page]).per(10)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,14 +2,14 @@ class UsersController < ApplicationController
   before_action :set_categorys
 
   def show
-    @nickname = current_user.nickname 
+    @nickname = User.find(params[:id]).nickname
   end
 
   def personal_infomation
     @user = User.find(params[:id])
     @address = Address.find(params[:id])
   end
-  
+
   def purchase_item
     @items = Item.where(buyer_id: current_user.id).page(params[:page]).per(10)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,10 @@ class UsersController < ApplicationController
     @nickname = current_user.nickname
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
   def personal_infomation
     @user = User.find(params[:id])
     @address = Address.find(params[:id])
@@ -28,4 +32,5 @@ class UsersController < ApplicationController
     @categories = Category.all  
   end
 
+  
 end

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -61,6 +61,9 @@
         = f.hidden_field :item_id, value:@item.id
       .actions
         = f.submit "変更する", class: "actions__btn"
+      = link_to  user_path do
+        .back-to-user-mypage
+          マイページに戻る
 = render partial: "template/banner"
 = render partial: "template/footer"
 

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -3,9 +3,13 @@
 
 .edit-user
   %h2
-    メールアドレス/パスワードの変更
+    ニックネーム/メールアドレス/パスワードの変更
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
     = render "devise/shared/error_messages", resource: resource
+    .field
+      = f.label :ニックネーム
+      %br/
+      = f.text_field :nickname, autocomplete: "nickname"
     .field
       = f.label :email
       %br/

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,4 +1,4 @@
--# = render partial: "template/header"
+= render partial: "template/header"
 = render partial: "template/sellbtn"
 
 .edit-user

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,48 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
+-# = render partial: "template/header"
+= render partial: "template/sellbtn"
+
+.edit-user
+  %h2
+    メールアドレス/パスワードの変更
+  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    .field
+      = f.label :email
       %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+      = f.email_field :email, autofocus: true, autocomplete: "email"
+    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+      %div
+        メールアドレス: #{resource.unconfirmed_email}  は、現在認証待ちです。
+    .field
+      = f.label :password
+      - if @minimum_password_length
+        %br/
+        %span
+          = @minimum_password_length
+          文字以上のパスワードを設定してください
+          %br/
+      %i (パスワードを変更
+      %span しない
+      場合は、
+      %span 空欄のまま
+      下の「変更する」のボタンを押してください)
+      %br/
+      = f.password_field :password, autocomplete: "new-password"
+    .field
+      = f.label :password_confirmation
+      %br/
+      = f.password_field :password_confirmation, autocomplete: "new-password"
+    .field
+      = f.label :current_password
+      %br/
+      %i (新しいパスワードに更新を希望する場合は、認証のため現在のパスワードを入力してください)
+      %br/
+      = f.password_field :current_password, autocomplete: "current-password"
+    .actions
+      = f.submit "変更する", class: 'change-btn'
+  = link_to :back do
+    .back-to-user-mypage
+      マイページに戻る
+
+= render partial: "template/banner"
+= render partial: "template/footer"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -35,7 +35,7 @@
     .field
       = f.label :current_password
       %br/
-      %i (新しいパスワードに更新を希望する場合は、認証のため現在のパスワードを入力してください)
+      %i (新しいEメールやパスワードに更新を希望する場合は、認証のため現在のパスワードを入力してください)
       %br/
       = f.password_field :current_password, autocomplete: "current-password"
     .actions

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -40,7 +40,7 @@
       = f.password_field :current_password, autocomplete: "current-password"
     .actions
       = f.submit "変更する", class: 'change-btn'
-  = link_to :back do
+  = link_to user_path(resource) do
     .back-to-user-mypage
       マイページに戻る
 

--- a/app/views/template/_footer.html.haml
+++ b/app/views/template/_footer.html.haml
@@ -19,6 +19,6 @@
         %li= link_to 'FURIMAロゴ利用ガイドライン', '#', class: "footer-link"
         %li= link_to 'お知らせ', '#', class: "footer-link"
   .main-footer__logo
-    = link_to '#' do
+    = link_to root_path do
       = image_tag "logo-white.png", class:"footer-logo"
       %p © FURIMA

--- a/app/views/users/_main_bar.html.haml
+++ b/app/views/users/_main_bar.html.haml
@@ -18,3 +18,6 @@
             %ul.showMypage-review-itemsBox
               %li 出品数
               %li 0
+  = link_to edit_user_registration_path do
+    .nickname_change
+      ニックネームを変更する

--- a/app/views/users/_main_bar.html.haml
+++ b/app/views/users/_main_bar.html.haml
@@ -7,8 +7,8 @@
 
       .main-information__showMypage-contents1__right
         .main-information__showMypage-contents1__right__upper
-          %h2 nickname
-          -# - @nickname
+          %h2
+            = @nickname
         .main-information__showMypage-contents1__right__lower
           .main-information__showMypage-contents1__right__lower__review
             %ul.showMypage-review-itemsBox

--- a/app/views/users/_side_bar.html.haml
+++ b/app/views/users/_side_bar.html.haml
@@ -34,6 +34,6 @@
       %li
         = link_to "支払い方法", controller: 'credit_cards'
       %li
-        = link_to "本人確認", personal_infomation_user_path
+        = link_to "登録されている個人情報", personal_infomation_user_path
       %li
         = link_to "ログアウト", controller: 'users', action: 'logout'

--- a/app/views/users/_side_bar.html.haml
+++ b/app/views/users/_side_bar.html.haml
@@ -36,4 +36,4 @@
       %li
         = link_to "登録されている個人情報", personal_infomation_user_path
       %li
-        = link_to "ログアウト", controller: 'users', action: 'logout'
+        = link_to "ログアウト", logout_user_path

--- a/app/views/users/_side_bar.html.haml
+++ b/app/views/users/_side_bar.html.haml
@@ -30,7 +30,7 @@
       %li
         = link_to "住所変更",edit_address_path(current_user.id)
       %li
-        = link_to "メール/パスワード変更"
+        = link_to "メール/パスワード変更", edit_user_registration_path
       %li
         = link_to "支払い方法", controller: 'credit_cards'
       %li

--- a/app/views/users/_side_bar.html.haml
+++ b/app/views/users/_side_bar.html.haml
@@ -34,6 +34,6 @@
       %li
         = link_to "支払い方法", controller: 'credit_cards'
       %li
-        = link_to "本人確認"
+        = link_to "本人確認", personal_infomation_user_path
       %li
         = link_to "ログアウト", controller: 'users', action: 'logout'

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -6,7 +6,7 @@
     = render "side_bar"
     
     .main-information
-      -if current_page?(logout_users_path)
+      -if current_page?(logout_user_path)
         .main-information__logout-btn
           = link_to "ログアウト", destroy_user_session_path, method: :delete
 

--- a/app/views/users/personal_infomation.html.haml
+++ b/app/views/users/personal_infomation.html.haml
@@ -8,21 +8,25 @@
     %h1.title
       登録されている個人情報
     %p.suggestion
-      変更したい場合は、下の「変更する」ボタンより変更をお願いします
+      送付先の住所を変更したい場合は、
+      %br/
+      下の「変更する」ボタンより変更をお願いします
     .name
       %span
         お名前
-      .last_name
-        = @user.last_name
-      .first_name
-        = @user.first_name
+      .name__ja
+        .last_name
+          = @user.last_name
+        .first_name
+          = @user.first_name
     .name__kana
       %span
         お名前カナ
-      .last_name__kana
-        = @user.last_name_kana
-      .first_name__kana
-        = @user.first_name_kana
+      .name__ja
+        .last_name__kana
+          = @user.last_name_kana
+        .first_name__kana
+          = @user.first_name_kana
     .birthday
       %span
         生年月日
@@ -53,7 +57,7 @@
         建物名
       .building__form
         = @address.building
-    = link_to '#', class: "link-btn" do
+    = link_to edit_address_path(current_user.id), class: "link-btn" do
       .link-btn
         変更する
 

--- a/app/views/users/personal_infomation.html.haml
+++ b/app/views/users/personal_infomation.html.haml
@@ -1,68 +1,61 @@
 = render partial: "template/header"
 = render partial: "template/sellbtn"
 
--# まだuserコントローラーに変数を記述していないためエラーが出てしまうのでコメントアウト
--# 今後、マイページをさらに実装するにあたり、本人確認情報が必要と判断し、参考コードを記述
--# .mypage
--#   .mypage__side_bar
--#     = render "side_bar"
--#   .mypage__personal-info
--#     %h1.title
--#       本人情報の入力
--#     %p.suggestion
--#       お客さまの本人情報をご登録ください。
--#     .name
--#       %span
--#         お名前
--#       %p.first_name
--#         = @user.first_name
--#       %p.last_name
--#         = @user.last_name
--#     .name__kana
--#       %span
--#         お名前カナ
--#       %p.first_name__kana
--#         = @user.first_name_kana
--#       %p.last_name__kana
--#         = @user.last_name_kana
--#     .birthday
--#       %span
--#         生年月日
--#       %p.birthday
--#         = @user.birthday
--#     .postal_code
--#       %span
--#         郵便番号
--#       .postal_code__form
--#         = form_with model: @address do |form|
--#           = form.text_field :postal_code
--#     .prefecture
--#       %span
--#         都道府県
--#       .prefecture__form
--#         = f.select
--#     .city 
--#       %span
--#         市区町村
--#       .city__form
--#         = form_with model: @address do |form|
--#           = form.text_field :city
--#     .block
--#       %span
--#         番地
--#       .block__form
--#         = form_with model: @address do |form|
--#           = form.text_field :block
--#     .building
--#       %span
--#         建物名
--#       .building__form
--#         = form_with model: @address do |form|
--#           = form.text_field :building
-
--#     %button{type: "submit", class:'btn'} 
--#       .submitbtn
--#         登録する
+.mypage__personal_infomation
+  .mypage__side_bar
+    = render "side_bar"
+  .personal_infomation
+    %h1.title
+      登録されている個人情報
+    %p.suggestion
+      変更したい場合は、下の「変更する」ボタンより変更をお願いします
+    .name
+      %span
+        お名前
+      .last_name
+        = @user.last_name
+      .first_name
+        = @user.first_name
+    .name__kana
+      %span
+        お名前カナ
+      .last_name__kana
+        = @user.last_name_kana
+      .first_name__kana
+        = @user.first_name_kana
+    .birthday
+      %span
+        生年月日
+      .birthday
+        = @user.birthday
+    .postal_code
+      %span
+        郵便番号
+      .postal_code
+        = @address.postal_code
+    .prefecture
+      %span
+        都道府県
+      .prefcture__name
+        = @address.prefecture.name
+    .city 
+      %span
+        市区町村
+      .city__form
+        = @address.city
+    .block
+      %span
+        番地
+      .block__form
+        = @address.block
+    .building
+      %span
+        建物名
+      .building__form
+        = @address.building
+    = link_to '#', class: "link-btn" do
+      .link-btn
+        変更する
 
 = render partial: "template/banner"
 = render partial: "template/footer"

--- a/app/views/users/personal_infomation.html.haml
+++ b/app/views/users/personal_infomation.html.haml
@@ -11,52 +11,75 @@
       送付先の住所を変更したい場合は、
       %br/
       下の「変更する」ボタンより変更をお願いします
-    .name
+    .content
       %span
         お名前
-      .name__ja
-        .last_name
+      .name
+        .name__last
           = @user.last_name
-        .first_name
+        .name__first
           = @user.first_name
-    .name__kana
+    .content
       %span
         お名前カナ
-      .name__ja
-        .last_name__kana
+      .name
+        .name__last
           = @user.last_name_kana
-        .first_name__kana
+        .name__first
           = @user.first_name_kana
-    .birthday
+    .content
       %span
         生年月日
       .birthday
         = @user.birthday
-    .postal_code
+    .destination
+      送付先の住所
+    .content
+      %span
+        送付先の住所の名前
+      .name
+        .name__last
+          = @address.destination_last_name
+        .name__first
+          = @address.destination_first_name
+    .content
+      %span
+        送付先の住所の名前(カナ)
+      .name
+        .name__last
+          = @address.destination_last_name_kana
+        .name__first
+          = @address.destination_first_name_kana
+    .content
       %span
         郵便番号
-      .postal_code
+      .postal_code_number
         = @address.postal_code
-    .prefecture
+    .content
       %span
         都道府県
       .prefcture__name
         = @address.prefecture.name
-    .city 
+    .content
       %span
         市区町村
-      .city__form
+      .city_name
         = @address.city
-    .block
+    .content
       %span
         番地
-      .block__form
+      .block__name
         = @address.block
-    .building
+    .content
       %span
         建物名
-      .building__form
+      .building__name
         = @address.building
+    .content
+      %span
+        電話番号
+      .phone_number
+        = @address.phone_numeber
     = link_to edit_address_path(current_user.id), class: "link-btn" do
       .link-btn
         変更する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,12 @@ Rails.application.routes.draw do
       get 'sell_item'
       get 'comment_item'
     end
+    member do
+      get 'personal_infomation', to: 'users#personal_infomation',
+      controllers: {
+        personal_infomation: 'users/personal_infomation'
+      }
+    end
   end
   resources :credit_cards, only: [:index, :new, :show] do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
   end
   resources :users, only: [:show] do
     collection do
-      get 'logout', to: 'users#logout'
       get 'purchase_item'
       get 'sell_item'
       get 'comment_item'
@@ -29,6 +28,7 @@ Rails.application.routes.draw do
       controllers: {
         personal_infomation: 'users/personal_infomation'
       }
+      get 'logout', to: 'users#logout'
     end
   end
   resources :credit_cards, only: [:index, :new, :show] do


### PR DESCRIPTION
# what
## outline
マイページのサイドバーに表示されている設定のメニューの、以下の2つのリンク先のページを作成、および機能実装をしました。
- メール/パスワード変更
- 登録されている個人情報
## details
- マイページに、そのユーザーのニックネームが表示されるようにしました。
- ヘッダーのカテゴリー表示機能が正常に動くように、他のコントローラーと同じようにbefore_actionでset_categoryが動くように設定しました。
- 「登録されている個人情報」のページから「住所変更」のページに移れるよう、サイドバーのメニューの他にリンクを作成して、ユーザーに分かりやすくしました。
- メールアドレス/パスワードの変更ページを、デフォルトの見た目から見やすくしました。
- メールアドレス/パスワードの変更ページから、変更しなくても元のマイページに戻れるようにリンクを作成しました。
- 「住所変更」など、ユーザー情報を更新した際に、デフォルトの「トップページにリダイレクトする」から、「ユーザーのマイページにリダイレクトする」ようにしました。
- ニックネームなどアカウント情報の変更ができるようにしました。(現状はニックネームのみフォームを用意しています。場所はメール、パスワードが変更できるようになっているページ、devise/registrations/edit.html.hamlです。)
# why
ユーザーマイページの機能を拡充することで、より世間でリリースされているフリマアプリに近づけるため。